### PR TITLE
Allow for 6 character .coffee domains

### DIFF
--- a/src/functions/vEmail.mjs
+++ b/src/functions/vEmail.mjs
@@ -31,7 +31,7 @@ export default function vEmail (val) {
     //  Validate domain content
     //  eslint-disable-next-line max-len
     if (/^(?:(?=[a-z0-9-]{1,63}\.)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?=[a-z0-9-]{1,63}z)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ig.test(parts[1]) !== false) return true;
-    if (/^(\w{1,})([.-]?\w)*(\.\w{2,5})+$/.test(parts[1]) === false) return false;
+    if (/^(\w{1,})([.-]?\w)*(\.\w{2,6})+$/.test(parts[1]) === false) return false;
 
     return true;
 }

--- a/test/src/functions/vEmail.test.mjs
+++ b/test/src/functions/vEmail.test.mjs
@@ -91,6 +91,10 @@ describe('vEmail', () => {
                 assert.ok(evaluation.is_valid);
             }
         });
+        it('email with 6 character TLD as correct', () => {
+            const evaluation = new Validator({a: 'email'}).validate({a: 'email@cof.coffee'});
+            assert.ok(evaluation.is_valid);
+        });
     });
 
     describe('Invalid', () => {


### PR DESCRIPTION
[RFC Spec 1035 ](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4) allows for 63 octect limits on all labales. There's a limitation in the current validator that doesn't allow `.coffee` domains to validate successfully because it's only testing for 2 - 5 characters on the TLD label.

I've bumped the character limit to 6 to allow for this one edgecase.